### PR TITLE
Split context value on Internal and Shared, memoize all of the provider functions, immediately pause work even if already subscribed to browser APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ import { DeferRenderProvider } from 'react-defer-renderer'
 ## TODO and road-map
 
 1. Write a lot of tests for the project. I have not wrote them yet because I had just the idea that was complex at first, and I still do not have a complete overview of how the complete version of the product will look like.
-2. Exclude `register`, `next` and `cleanUp` from `DeferContext`, because they are meant for internal use.
-3. When pausing a work that has been granted but the delay has not being resolved yet, the work should be interrupted immediately.
+2. <s>Exclude `register`, `next` and `cleanUp` from `DeferContext`, because they are meant for internal use.</s>
+3. <s>When pausing a work that has been granted but the delay has not being resolved yet, the work should be interrupted immediately.</s>
 4. Support `props` resolve to defer the render of a component until some props has same exact values.
 5. Support `Promise` resolve to defer the render until a promise resolves.
 

--- a/example/package.json
+++ b/example/package.json
@@ -8,6 +8,7 @@
     "@material-ui/core": "^4.8.3",
     "@material-ui/icons": "^4.5.1",
     "clsx": "^1.1.0",
+    "lodash": "^4.17.15",
     "prop-types": "^15.6.2",
     "react": "link:../node_modules/react",
     "react-defer-renderer": "link:..",

--- a/example/src/Todos.js
+++ b/example/src/Todos.js
@@ -83,7 +83,7 @@ function Todos() {
   //   renderRef.current++
   // })
   React.useEffect(() => {
-    const allTodos = range(100).map(t => ({
+    const allTodos = range(1000).map(t => ({
       id: t,
       userId: t,
       title: `This is the todo with index ${t}`,

--- a/example/src/Todos.js
+++ b/example/src/Todos.js
@@ -3,6 +3,7 @@ import * as PropTypes from 'prop-types'
 import { makeStyles } from '@material-ui/core/styles'
 import Grid from '@material-ui/core/Grid'
 import { withDeferRender } from 'react-defer-renderer'
+import { isEqual } from 'lodash'
 
 function range(size, startAt = 0) {
   return [...Array(size).keys()].map(i => i + startAt)
@@ -72,6 +73,7 @@ ToDo.propTypes = {
 }
 
 const DeferredTodo = withDeferRender(ToDo) //, { fallback: <CircularProgress /> })
+const MemoizedTodo = React.memo(DeferredTodo, isEqual)
 
 function Todos() {
   const renderRef = React.useRef(0)
@@ -81,7 +83,7 @@ function Todos() {
   //   renderRef.current++
   // })
   React.useEffect(() => {
-    const allTodos = range(1000).map(t => ({
+    const allTodos = range(100).map(t => ({
       id: t,
       userId: t,
       title: `This is the todo with index ${t}`,
@@ -91,7 +93,7 @@ function Todos() {
   }, [renderRef.current])
   return (
     <Grid style={{ flexFlow: 'wrap-reverse' }} container>
-      {todos.sort((a, b) => b.id - a.id).map(todo => <DeferredTodo key={`${renderRef.current}-${todo.id}`} {...todo} />)}
+      {todos.sort((a, b) => b.id - a.id).map(todo => <MemoizedTodo key={`${renderRef.current}-${todo.id}`} {...todo} />)}
     </Grid>
   )
 }

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -235,6 +235,11 @@ jss@^10.0.0, jss@^10.0.3:
     is-in-browser "^1.1.3"
     tiny-warning "^1.0.2"
 
+lodash@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"

--- a/src/Context.js
+++ b/src/Context.js
@@ -1,5 +1,0 @@
-import React from 'react'
-
-const DeferContext = React.createContext(null)
-
-export default DeferContext

--- a/src/DeferContext.js
+++ b/src/DeferContext.js
@@ -1,0 +1,17 @@
+import React from 'react'
+
+/**
+ * This is the defer context that developers will be able to consume
+ * It provides pause and resume features
+ * @type {React.Context<null>}
+ */
+const DeferContext = React.createContext(null)
+
+/**
+ * Will provide features meant to be used internally
+ * Like register, cleanUp and next
+ * @type {React.Context<null>}
+ */
+export const InternalDeferContext = React.createContext(null)
+
+export default DeferContext

--- a/src/DeferRenderProvider.js
+++ b/src/DeferRenderProvider.js
@@ -301,6 +301,13 @@ function DeferRenderProvider({
    */
   const pause = React.useCallback(() => {
     workStatus.current = __WORK_STATUS.PAUSED
+    currentWorkQueue.current.forEach(ongoingWork => {
+      if (ongoingWork.ready && !ongoingWork.done) {
+        window.cancelAnimationFrame(ongoingWork.rafId)
+        clearTimeout(ongoingWork.timeoutId)
+      }
+    })
+    currentWorkQueue.current = []
   }, [])
 
   /**

--- a/src/DeferRenderProvider.js
+++ b/src/DeferRenderProvider.js
@@ -1,6 +1,6 @@
-import React from 'react'
+import * as React from 'react'
 import PropTypes from 'prop-types'
-import DeferContext from './Context'
+import DeferContext, { InternalDeferContext } from './DeferContext'
 
 /**
  * represents the work status
@@ -23,7 +23,14 @@ const __DEFER_MODES = {
  * just returns a work object to be saved in the context
  */
 function makeNewWork(work, index) {
-  return { work, index, ready: false, done: false, timeoutId: null, rafId: null }
+  return {
+    work,
+    index,
+    ready: false,
+    done: false,
+    timeoutId: null,
+    rafId: null
+  }
 }
 
 /**
@@ -95,7 +102,7 @@ function DeferRenderProvider({
    * It is important to note that this function is used to subscribe deferred components
    * and should return an identifier that will used in the clean-up function
    */
-  function register(work) {
+  const register = React.useCallback(work => {
     /**
      * The index tracker is used to identify works
      * it is basically an auto-increment integer value
@@ -116,30 +123,35 @@ function DeferRenderProvider({
     }
     /** The work index will be given to the clean up function to identify which work to clean */
     return newWork.index
-  }
+  }, [])
 
   /**
    * With the asynchronous behavior of components' subscription and the work being randomly executed in several ways
    * It is important to control the work status
    * this function will only set the work status to idle if there is no more work in the current work queue
    */
-  function reconcileWorkStatus() {
-    if (currentWorkQueue.current.length === 0 && workStatus.current !== __WORK_STATUS.PAUSED) {
+  const reconcileWorkStatus = React.useCallback(() => {
+    if (
+      currentWorkQueue.current.length === 0 &&
+      workStatus.current !== __WORK_STATUS.PAUSED
+    ) {
       workStatus.current = __WORK_STATUS.IDLE
       next()
     }
-  }
+  }, [])
 
   /**
    * This function will remove a work entirely from both the work queue and the current work queue
    * It is executed after a work is done
-   * So basically; after a work is done, it is immediatly removed and the work status is reconciled
+   * So basically; after a work is done, it is immediately removed and the work status is reconciled
    */
-  function removeWork(work) {
+  const removeWork = React.useCallback(work => {
     workQueue.current = workQueue.current.filter(t => t.index !== work.index)
-    currentWorkQueue.current = currentWorkQueue.current.filter(t => t.index !== work.index)
+    currentWorkQueue.current = currentWorkQueue.current.filter(
+      t => t.index !== work.index
+    )
     reconcileWorkStatus()
-  }
+  }, [])
 
   /**
    * This is actually the work
@@ -149,16 +161,16 @@ function DeferRenderProvider({
    * the work, if not done, may be executed from a next call from a previously rendered component
    * All defer modes pass through this function
    */
-  function commitWork(work) {
+  const commitWork = React.useCallback(work => {
     work.work()
     work.done = true
     removeWork(work)
-  }
+  }, [])
 
   /**
    * This function is executed in both modes: SEQUENTIAL and ASYNC_CONCURRENT
    */
-  function asyncProcessCurrentWork() {
+  const asyncProcessCurrentWork = React.useCallback(() => {
     /** the work status need to be either idle or working, if paused, we should do nothing **/
     if (workStatus.current !== __WORK_STATUS.PAUSED) {
       /** flag the work status as working **/
@@ -174,26 +186,26 @@ function DeferRenderProvider({
         })
       })
     }
-  }
+  }, [])
 
   /**
    * This function is executed when using the sync defer mode
    */
-  function processCurrentWork() {
+  const processCurrentWork = React.useCallback(() => {
     if (workStatus.current !== __WORK_STATUS.PAUSED) {
       workStatus.current = __WORK_STATUS.WORKING
       // will immediately commit all work in the current work queue.
       // aka: the sliced batchSize from the remaining work in the queue
       currentWorkQueue.current.forEach(commitWork)
     }
-  }
+  }, [])
 
   /**
    * This function is called only from the `next` function
    * but it is the main function of the provider
    * depending on the defer mode, will execute the corresponding function (processCurrentWork or asyncProcessCurrentWork)
    */
-  function beginWork() {
+  const beginWork = React.useCallback(() => {
     /** immediately exit if there is no work in the main queue **/
     if (workQueue.current.length === 0) {
       return
@@ -221,9 +233,14 @@ function DeferRenderProvider({
     } else if (modeRef.current === __DEFER_MODES.SYNC) {
       if (currentWorkQueue.current.length === 0) {
         /** take either the batch size or the whole work and send it to the current work queue **/
-        const nextWork = workQueue.current.slice(0, batchSizeRef.current || workQueue.current.length)
+        const nextWork = workQueue.current.slice(
+          0,
+          batchSizeRef.current || workQueue.current.length
+        )
         currentWorkQueue.current.push(...nextWork)
-        currentWorkQueue.current.forEach(t => { t.ready = true })
+        currentWorkQueue.current.forEach(t => {
+          t.ready = true
+        })
       }
       setTimeout(processCurrentWork, delayRef.current)
       /**
@@ -234,29 +251,37 @@ function DeferRenderProvider({
     } else if (modeRef.current === __DEFER_MODES.ASYNC_CONCURRENT) {
       if (currentWorkQueue.current.length === 0) {
         /** take either the batch size or the whole work and send it to the current work queue **/
-        const nextWork = workQueue.current.slice(0, batchSizeRef.current || workQueue.current.length)
+        const nextWork = workQueue.current.slice(
+          0,
+          batchSizeRef.current || workQueue.current.length
+        )
         currentWorkQueue.current.push(...nextWork)
-        currentWorkQueue.current.forEach(t => { t.ready = true })
+        currentWorkQueue.current.forEach(t => {
+          t.ready = true
+        })
       }
       asyncProcessCurrentWork()
     }
-  }
+  }, [])
 
   /**
    * This is the entry-point of all work; it only checks that the work status is idle and that there is something the queue, then triggers the beginWork function
    * This function is also called each time a deferred component renders
    */
-  function next() {
-    if (workStatus.current === __WORK_STATUS.IDLE && workQueue.current.length > 0) {
+  const next = React.useCallback(() => {
+    if (
+      workStatus.current === __WORK_STATUS.IDLE &&
+      workQueue.current.length > 0
+    ) {
       beginWork()
     }
-  }
+  }, [])
 
   /**
    * If a tree get unmounted, it is important to remove all the associated work to avoid calling the callback
    * after we are granted the animation frame or the timeout resolves
    */
-  function cleanUp(index) {
+  const cleanUp = React.useCallback(index => {
     /** grab the work given the identifier we are trying to remove **/
     const fromCurrent = currentWorkQueue.current.find(t => t.index === index)
     /**
@@ -268,23 +293,23 @@ function DeferRenderProvider({
     }
     /** Remove the work from both queues **/
     removeWork({ index })
-  }
+  }, [])
 
   /**
    * To pause a work, it is only necessary to flag the work status as PAUSED
    * todo: unsubscribe from the animation frame and/or the timeout and remove the work only from the currentWorkQueue
    */
-  function pause() {
+  const pause = React.useCallback(() => {
     workStatus.current = __WORK_STATUS.PAUSED
-  }
+  }, [])
 
   /**
    * To resume the work, we need to flag the status as idle then call next
    */
-  function resume() {
+  const resume = React.useCallback(() => {
     workStatus.current = __WORK_STATUS.IDLE
     next()
-  }
+  }, [])
 
   /**
    * After each provider render, it will trigger the work
@@ -293,16 +318,23 @@ function DeferRenderProvider({
     next()
   })
 
+  const internalContextValue = React.useMemo(() => ({
+    next,
+    cleanUp,
+    register
+  }), [])
+
+  const sharedContextValue = React.useMemo(() => ({
+    pause,
+    resume
+  }), [])
+
   return (
-    <DeferContext.Provider value={{
-      next,
-      pause,
-      resume,
-      cleanUp,
-      register
-    }}>
-      {children}
-    </DeferContext.Provider>
+    <InternalDeferContext.Provider value={internalContextValue}>
+      <DeferContext.Provider value={sharedContextValue}>
+        {children}
+      </DeferContext.Provider>
+    </InternalDeferContext.Provider>
   )
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import withDeferRender from './withDeferRender'
 import DeferRenderProvider from './DeferRenderProvider'
-import DeferContext from './Context'
+import DeferContext from './DeferContext'
 
 export { DeferRenderProvider, withDeferRender, DeferContext }

--- a/src/withDeferRender.js
+++ b/src/withDeferRender.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import DeferContext from './Context'
+import { InternalDeferContext } from './DeferContext'
 
 /**
  * This function will ask the browser for an animation frame
@@ -55,7 +55,7 @@ export default function withDeferRender(WrappedComponent, config) {
      * First, we retrieve the DeferContext value
      * Then we will try to init the register, next and cleanUp functions
      */
-    const contextValue = React.useContext(DeferContext)
+    const contextValue = React.useContext(InternalDeferContext)
     const register = contextValue?.register || standaloneRegister
     const next = contextValue?.next
     const cleanUp = contextValue?.cleanUp || standaloneCleanUp


### PR DESCRIPTION
- Add another provider and split the value on `internal` and `shared`: 
The internal value will be used internally and contains the `register`, `cleanUp` and `next` functions. They aren't meant for external usage.
The share value will be used to order the provider to `stop` and `resume` the render process
- memoize all of the defer provider functions with the mount memoization, they are working on mutable objects (refs) and thus there is no closures issue when memoizing them.
- Remove not done work from `currentWorkQueue` when pausing work to avoid them rendering after triggering the pause event
